### PR TITLE
Remove Flux persistent storage configuration and update worker nodes size

### DIFF
--- a/flux/fluxinstance.yaml
+++ b/flux/fluxinstance.yaml
@@ -24,9 +24,6 @@ spec:
     multitenant: false
     networkPolicy: true
     domain: "cluster.local"
-  storage:
-    class: "standard"
-    size: "10Gi"
   commonMetadata:
     labels:
       app.kubernetes.io/name: flux

--- a/single-master-k8s/locals.tf
+++ b/single-master-k8s/locals.tf
@@ -9,9 +9,9 @@ locals {
   ssh_key_name                = "ic-k8slab-cluster-${substr(sha1(tls_private_key.ic-k8slab-cluster.public_key_openssh), 0, 8)}"
 
   instance_type = {
-    workers1 = "t2.micro"
-    workers3 = "t2.micro"
-    workers5 = "t2.micro"
+    workers1 = "t2.small"
+    workers3 = "t2.small"
+    workers5 = "t2.small"
     masters1 = "t2.medium"
   }
 


### PR DESCRIPTION
FluxInstance resource had persistent storage configuration - since we do not have any storage driver yet - Flux source controller couldn't start.
tX.micro instances were too small to run with Flux PODs.